### PR TITLE
Correction to AppDrawer RecyclerView paddings

### DIFF
--- a/app/src/main/res/layout/fragment_app_drawer.xml
+++ b/app/src/main/res/layout/fragment_app_drawer.xml
@@ -1,81 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mainLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:animateLayoutChanges="true"
     android:background="?attr/primaryShadeDarkColor">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/search"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="88dp"
-        android:animateLayoutChanges="true"
-        android:orientation="horizontal">
+        android:layout_marginBottom="14dp"
+        android:gravity="end"
+        android:imeOptions="actionSearch"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="0dp"
+        android:textCursorDrawable="@null"
+        app:closeIcon="@null"
+        app:iconifiedByDefault="false"
+        app:layout_constraintBottom_toTopOf="@+id/recyclerView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:queryBackground="@null"
+        app:queryHint="__"
+        app:searchIcon="@null"
+        app:theme="@style/AppSearchText" />
 
-        <androidx.appcompat.widget.SearchView
-            android:id="@+id/search"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="end"
-            android:imeOptions="actionSearch"
-            android:paddingHorizontal="8dp"
-            android:paddingVertical="0dp"
-            android:textCursorDrawable="@null"
-            app:closeIcon="@null"
-            app:iconifiedByDefault="false"
-            app:queryBackground="@null"
-            app:queryHint="__"
-            app:searchIcon="@null"
-            app:theme="@style/AppSearchText" />
-    </LinearLayout>
 
     <TextView
         android:id="@+id/drawerButton"
         style="@style/TextSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        android:layout_marginTop="52dp"
-        android:layout_marginEnd="24dp"
         android:paddingVertical="@dimen/app_padding_vertical"
         android:textAllCaps="true"
-        android:visibility="gone" />
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/appDrawerTip"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="52dp"
-        android:layout_marginEnd="4dp"
         android:ellipsize="end"
         android:maxLines="1"
         android:text="@string/app_drawer_tips"
         android:textColor="?attr/primaryColor"
         android:textSize="16sp"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="150dp"
-        android:layout_marginBottom ="50dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="32dp"
         android:clipChildren="false"
         android:clipToPadding="false"
         android:overScrollMode="never"
-        android:paddingBottom="48dp" />
+        android:paddingBottom="48dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/search" />
 
     <TextView
         android:id="@+id/listEmptyHint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="@string/drawer_list_empty_hint"
         android:textSize="20sp"
-        android:layout_gravity="center"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### Type of change <!-- required to be filled in -->

- [x] Bugfix (user facing) <!-- non-breaking change which fixes an issue -->

### All Submissions <!-- to be checked but remove any that are not required -->

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change? <!-- required -->
- [x] Have you made a descriptive commit message with a short title (first line). <!-- required -->
- [x] Have you performed a self-review of your code <!-- required -->
- [ ] Have you commented your code, particularly in hard-to-understand areas <!-- required -->
- [x] My changes generate no new warnings or errors of any kind <!-- required -->
- [x] You have done your changes in a separate branch. <!-- required -->
- [x] Branch has descriptive name that start with either the `bug/` `feat/` or `clean/`  prefixes. <!-- required --> 
<!-- Good examples are: 'bug/signin-issue' 'feat/issue-templates' or 'clean/code-change-to-app-draw'. -->

### Description of the changes in your PR

I noticed that when using Left and Right alignments for the app drawer they are pinned right to the screen edge. I'm not sure if this is a bug or feature but I don't like it. I converted recyclerView to constraint-based widget and added 24dp and 32dp padding for the sides and bottom respectively.


### Test Device: <!-- required -->
- mLauncher version: based off main@40430ea05e805d568dc877694948301dadf1404d
- Device name: Resizable (Experimental) API 33
- Android version: 13
- Other information: Emulator used for testing

